### PR TITLE
Tweaks

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,16 @@ parts:
     prime:
       - usr/lib/*/gstreamer-1.0/libgstopengl.so
 
+  cleanup:
+    after: [snapshot]
+    plugin: nil
+    build-snaps: [core22, gnome-42-2204]
+    override-prime: |
+      set -eux
+      for snap in "core22" "gnome-42-2204"; do
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" \;
+      done
+
   snapshot:
     after: [ rustup ]
     plugin: meson

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,25 @@ parts:
     override-prime: |
       echo 'Skip Prime'
 
+  pipewire:
+    source: https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/0.3.79/pipewire-0.3.79.tar.gz
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - --strip
+      - -Dalsa=disabled
+      - -Dpipewire-alsa=disabled
+      - -Djack=disabled
+      - -Dpipewire-jack=disabled
+      - -Dsession-managers=[]
+    prime:
+      - usr/lib/*/pipewire-*
+      - usr/lib/*/spa-*
+      - usr/lib/*/libpipewire*.so*
+      - usr/lib/*/gstreamer-1.0/*.so
+      - usr/share/pipewire
+
   snapshot:
     after: [ rustup ]
     plugin: meson
@@ -60,6 +79,10 @@ apps:
     desktop: usr/share/applications/org.gnome.Snapshot.desktop
     extensions: [ gnome ]
     common-id: org.gnome.Snapshot
+    environment:
+      PIPEWIRE_CONFIG_NAME: "$SNAP/usr/share/pipewire/pipewire.conf"
+      PIPEWIRE_MODULE_DIR: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pipewire-0.3"
+      SPA_PLUGIN_DIR: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/spa-0.2"
     plugs:
       - camera
       - audio-playback

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,14 @@ parts:
       - usr/lib/*/gstreamer-1.0/*.so
       - usr/share/pipewire
 
+# should perhaps be in the sdk instead
+  gstreamer:
+    plugin: nil
+    stage-packages:
+      - gstreamer1.0-gl
+    prime:
+      - usr/lib/*/gstreamer-1.0/libgstopengl.so
+
   snapshot:
     after: [ rustup ]
     plugin: meson


### PR DESCRIPTION
It's a bit hackish but for testing

The gstreamer-gl binary is built from base and could perhaps be including in the gnome snap (needs to check if the gl depends are ok there)

The application requires a newer pipewire so we are building it from source (using the version available in mantic for testing), the part i copied from what firefox used to do before it switch to core22 (so build options and env should work somehow)