### PR TITLE
set GST_PRESET_PATH to fix gstreamer errors

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,6 +98,7 @@ apps:
     extensions: [ gnome ]
     common-id: org.gnome.Snapshot
     environment:
+      GST_PRESET_PATH: "$SNAP/gnome-platform/usr/share/gstreamer-1.0/presets"
       PIPEWIRE_CONFIG_NAME: "$SNAP/usr/share/pipewire/pipewire.conf"
       PIPEWIRE_MODULE_DIR: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pipewire-0.3"
       SPA_PLUGIN_DIR: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/spa-0.2"


### PR DESCRIPTION
Unsure why but that seems required for gstreamer to work correctly. Unsure why it doesn't impact other gstreamer applications though and if that should be set by the gnome launcher script?